### PR TITLE
Adding $REPOROOT configuration variable recognition

### DIFF
--- a/docs/exitcodes.md
+++ b/docs/exitcodes.md
@@ -7,6 +7,7 @@ FAILURE
 10	not in a project directory
 11	no release config dir found
 12	no config files in .release
+13	$REPOROOT not set in release configuration
 
 20	no option selected
 

--- a/include/functions.sh
+++ b/include/functions.sh
@@ -364,9 +364,14 @@ function_setup_git() {
         exit 10
     fi
 
+    if [ -z ${REPOROOT} ]; then
+        fn_dialog_error "Variable \$REPOROOT is not set. Please add this to your release config. Example: git@github.com:bytepark/"
+        exit 13
+    fi
+
     # set the PROJECT VAR with correct name from repo
     PROJECT=${REPO}
-    GITREPO="ssh://elena.bytenetz.de/git/${REPO}.git"
+    GITREPO="${REPOROOT}${REPO}.git"
 
     function_ask_revision
 }


### PR DESCRIPTION
You can now set $REPOROOT within your release configuration in order to allow fetching repositories from other sources.
